### PR TITLE
Migrating exception from javax to jakarta package

### DIFF
--- a/src/main/java/org/apache/openejb/cts/JMSAdminImpl.java
+++ b/src/main/java/org/apache/openejb/cts/JMSAdminImpl.java
@@ -26,7 +26,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTopic;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 import java.io.PrintWriter;
 
 public class JMSAdminImpl implements TSJMSAdminInterface {


### PR DESCRIPTION
Class JMSAdminImpl still used javax.jms.JMSException instead of corresponding jakarta.jms.JMSException, causing compilation error.